### PR TITLE
fix: add back 3.7 to pyproject.toml for compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
     "deprecated>=1.2.14",
     "pandas",


### PR DESCRIPTION
We don't test it as it's a legacy support.